### PR TITLE
added zigbee/power configuration option to override default tx power …

### DIFF
--- a/adapter.cpp
+++ b/adapter.cpp
@@ -43,6 +43,7 @@ Adapter::Adapter(QSettings *config, QObject *parent) : QObject(parent), m_receiv
 
     m_panId = static_cast <quint16> (config->value("zigbee/panid", "0x1A62").toString().toInt(nullptr, 16));
     m_channel = static_cast <quint8> (config->value("zigbee/channel").toInt());
+    m_power = static_cast <quint8> (config->value("zigbee/power", "0").toUInt());
 
     m_write = config->value("zigbee/write", false).toBool();
     m_portDebug = config->value("debug/port", false).toBool();

--- a/adapter.h
+++ b/adapter.h
@@ -199,6 +199,7 @@ protected:
     QString m_bootPin, m_resetPin, m_reset;
     quint16 m_panId;
     quint8 m_channel;
+    quint8 m_power;
     bool m_write, m_portDebug, m_adapterDebug;
 
     QString m_manufacturerName, m_modelName, m_firmware;

--- a/ezsp.cpp
+++ b/ezsp.cpp
@@ -444,7 +444,7 @@ bool EZSP::startNetwork(quint64 extendedPanId)
 
     network.extendedPanId = extendedPanId;
     network.panId = qToLittleEndian(m_panId);
-    network.txPower = 0x05;
+    network.txPower = m_power ? m_power : ASH_DEFAULT_TXPOWER;
     network.channel = m_channel;
     network.channelList = qToLittleEndian(1 << m_channel);
 
@@ -628,7 +628,8 @@ bool EZSP::startCoordinator(void)
 
     memcpy(&network, m_replyData.constData() + 2, sizeof(network));
 
-    if (m_replyData.at(1) != 0x01 || network.extendedPanId != ieeeAddress || network.panId != qToLittleEndian(m_panId) || network.channel != m_channel || m_stackStatus != STACK_STATUS_NETWORK_UP)
+    if (m_replyData.at(1) != 0x01 || network.extendedPanId != ieeeAddress || network.panId != qToLittleEndian(m_panId) || network.channel != m_channel || m_stackStatus != STACK_STATUS_NETWORK_UP
+        || network.txPower != (m_power ? m_power : ASH_DEFAULT_TXPOWER))
     {
         logWarning << "Adapter network parameters doesn't match configuration";
         check = true;

--- a/ezsp.h
+++ b/ezsp.h
@@ -5,6 +5,7 @@
 #define ASH_REQUEST_RETRIES                                     3
 #define ASH_MIN_LENGTH                                          4
 #define ASH_FLAG_BYTE                                           0x7E
+#define ASH_DEFAULT_TXPOWER                                     0x05
 
 #define ASH_CONTROL_ACK                                         0x80
 #define ASH_CONTROL_NAK                                         0xA0

--- a/zstack.cpp
+++ b/zstack.cpp
@@ -501,7 +501,7 @@ bool ZStack::startCoordinator(void)
     if (!sendRequest(ZDO_ADD_GROUP, QByteArray(reinterpret_cast <char*> (&request), sizeof(request))) || m_replyData.at(0))
         logWarning << "Add GP group request failed";
 
-    if (!sendRequest(SYS_SET_TX_POWER, QByteArray(1, 0x14)) || m_replyData.at(0))
+    if (!sendRequest(SYS_SET_TX_POWER, QByteArray(1, m_power ? m_power: ZSTACK_DEFAULT_TXPOWER)) || m_replyData.at(0))
         logWarning << "Set TX power request failed";
 
     if (!sendRequest(ZDO_STARTUP_FROM_APP, QByteArray(2, 0x00)) || m_replyData.at(0) == 0x02)

--- a/zstack.h
+++ b/zstack.h
@@ -4,6 +4,7 @@
 #define ZSTACK_CONFIGURATION_MARKER                 0x42
 #define ZSTACK_CLEAR_DELAY                          4000
 #define ZSTACK_REQUEST_TIMEOUT                      10000
+#define ZSTACK_DEFAULT_TXPOWER                      0x14
 
 #define ZSTACK_SKIP_BOOTLOADER                      0xEF
 #define ZSTACK_PACKET_FLAG                          0xFE


### PR DESCRIPTION
…for ZStack\EZSP adapters.

Reason: my 2652 board cannot work with default 0x14 tx power. Need to configure it somehow ;)
EZSP is also changed, but I cannot test it. TxPower for zgate was not found :(