### PR TITLE
added "togglePermitJoin" action (with no params) to toggle Zigbee "permit_join" mode

### DIFF
--- a/adapter.cpp
+++ b/adapter.cpp
@@ -128,6 +128,11 @@ void Adapter::setPermitJoin(bool enabled)
     }
 }
 
+void Adapter::togglePermitJoin()
+{
+    setPermitJoin(!m_permitJoin);
+}
+
 bool Adapter::waitForSignal(const QObject *sender, const char *signal, int tiomeout)
 {
     QEventLoop loop;

--- a/adapter.h
+++ b/adapter.h
@@ -175,6 +175,7 @@ public:
 
     void init(void);
     void setPermitJoin(bool enabled);
+    void togglePermitJoin();
     bool waitForSignal(const QObject *sender, const char *signal, int tiomeout);
 
     virtual bool zdoRequest(quint8 id, quint16 networkAddress, quint16 clusterId, const QByteArray &data = QByteArray());

--- a/controller.cpp
+++ b/controller.cpp
@@ -73,6 +73,10 @@ void Controller::mqttReceived(const QByteArray &message, const QMqttTopicName &t
                 m_zigbee->setPermitJoin(json.value("enabled").toBool());
                 break;
 
+            case Command::togglePermitJoin:
+                m_zigbee->togglePermitJoin();
+                break;
+
             case Command::setDeviceName:
                 m_zigbee->setDeviceName(json.value("device").toString(), json.value("name").toString());
                 break;

--- a/controller.h
+++ b/controller.h
@@ -20,6 +20,7 @@ public:
     {
         restartService,
         setPermitJoin,
+        togglePermitJoin,
         removeDevice,
         setDeviceName,
         updateDevice,

--- a/zigbee.cpp
+++ b/zigbee.cpp
@@ -69,6 +69,14 @@ void ZigBee::setPermitJoin(bool enabled)
     m_adapter->setPermitJoin(enabled);
 }
 
+void ZigBee::togglePermitJoin()
+{
+    if (!m_adapter)
+        return;
+
+    m_adapter->togglePermitJoin();
+}
+
 void ZigBee::removeDevice(const QString &deviceName, bool force)
 {
     Device device = m_devices->byName(deviceName);

--- a/zigbee.h
+++ b/zigbee.h
@@ -117,6 +117,7 @@ public:
 
     void init(void);
     void setPermitJoin(bool enabled);
+    void togglePermitJoin();
 
     void removeDevice(const QString &deviceName, bool force);
     void setDeviceName(const QString &deviceName, const QString &name);


### PR DESCRIPTION
This action allows to toggle Zigbee "permit join". 
Here is example how to toggle "permit join" mode by pressing WPS button on Perenio PEACG01 under OpenWRT (package "mosquitto-client-nossl" is needed):
```
root@PEACG01:~# cat /etc/rc.button/wps
#!/bin/sh

if [ "$ACTION" = "released" ] && [ "$BUTTON" = "wps" ]; then
        CONF=/etc/homed/homed-zigbee.conf
        HOST=`sed -nr "/^\[mqtt\]/ { :l /^host[ ]*=/ { s/[^=]*=[ ]*//; p; q;}; n; b l;}" $CONF`
        PORT=`sed -nr "/^\[mqtt\]/ { :l /^port[ ]*=/ { s/[^=]*=[ ]*//; p; q;}; n; b l;}" $CONF`
        USER=`sed -nr "/^\[mqtt\]/ { :l /^username[ ]*=/ { s/[^=]*=[ ]*//; p; q;}; n; b l;}" $CONF`
        PASW=`sed -nr "/^\[mqtt\]/ { :l /^password[ ]*=/ { s/[^=]*=[ ]*//; p; q;}; n; b l;}" $CONF`
        PREF=`sed -nr "/^\[mqtt\]/ { :l /^prefix[ ]*=/ { s/[^=]*=[ ]*//; p; q;}; n; b l;}" $CONF`
        mosquitto_pub -h $HOST -p $PORT -i $USER -u $USER -P $PASW -t "$PREF/command/zigbee" -m "{\"action\": \"togglePermitJoin\"}"
fi

return 0
```