### PR TITLE
update _TZ3000_xkap8wtb config

### DIFF
--- a/deploy/data/usr/share/homed-zigbee/tuya.json
+++ b/deploy/data/usr/share/homed-zigbee/tuya.json
@@ -898,24 +898,14 @@
       "endpointId":     [1, 2, 3, 4, 5, 6]
     },
     {
-      "description":    "TUYA TS0001 1-Channel Relay with Power Monitoring",
-      "modelNames":     ["_TZ3000_g92baclx", "_TZ3000_kqvb5akv", "_TZ3000_mkhkxx1p", "_TZ3000_qnejhcsu", "_TZ3000_tgddllx4", "_TZ3000_x3ewpzyr"],
-      "properties":     ["status", "energy", "voltage", "current", "power", "tuyaPowerOnStatus"],
-      "actions":        ["status", "tuyaPowerOnStatus"],
+      "description":    "TUYA TS0001 or TS000F 1-Channel Relay with Power Monitoring",
+      "modelNames":     ["_TZ3000_g92baclx", "_TZ3000_kqvb5akv", "_TZ3000_mkhkxx1p", "_TZ3000_qnejhcsu", "_TZ3000_tgddllx4", "_TZ3000_x3ewpzyr", "_TZ3000_xkap8wtb"],
+      "properties":     ["status", "energy", "voltage", "current", "power", "tuyaSwitchType", "tuyaPowerOnStatus"],
+      "actions":        ["status", "tuyaSwitchType", "tuyaPowerOnStatus"],
       "bindings":       ["status", "energy", "power"],
       "reportings":     ["status", "energy", "voltage", "current", "power"],
-      "exposes":        ["switch", "powerOnStatus", "energy", "voltage", "current", "power"],
-      "options":        {"powerOnStatus": {"enum": ["off", "on", "previous"]}, "energyDivider": 100, "currentDivider": 1000, "tuyaMagic": true, "skipAttributeRead": true}
-    },
-    {
-      "description":    "TUYA TS000F 1-Channel Relay with Power Monitoring",
-      "modelNames":     ["_TZ3000_xkap8wtb"],
-      "properties":     ["status", "energy", "voltage", "current", "power", "tuyaChildLock", "tuyaIndicatorMode", "tuyaSwitchType", "tuyaPowerOnStatus"],
-      "actions":        ["status", "tuyaChildLock", "tuyaIndicatorMode", "tuyaSwitchType", "tuyaPowerOnStatus"],
-      "bindings":       ["status", "energy", "power"],
-      "reportings":     ["status", "energy", "voltage", "current", "power"],
-      "exposes":        ["switch", "childLock", "indicatorMode", "switchType", "powerOnStatus", "energy", "voltage", "current", "power"],
-      "options":        {"switchType": {"enum": ["toggle", "static", "momentary"]}, "powerOnStatus": {"enum": ["off", "on", "previous"]}, "energyDivider": 100, "currentDivider": 1000, "tuyaMagic": true}
+      "exposes":        ["switch", "switchType", "powerOnStatus", "energy", "voltage", "current", "power"],
+      "options":        {"switchType": {"enum": ["toggle", "static", "momentary"]}, "powerOnStatus": {"enum": ["off", "on", "previous"]}, "energyDivider": 100, "currentDivider": 1000, "tuyaMagic": true, "skipAttributeRead": true}
     },
     {
       "description":    "TUYA TS011F 1-Channel Relay with Power Monitoring",

--- a/deploy/data/usr/share/homed-zigbee/tuya.json
+++ b/deploy/data/usr/share/homed-zigbee/tuya.json
@@ -899,13 +899,23 @@
     },
     {
       "description":    "TUYA TS0001 1-Channel Relay with Power Monitoring",
-      "modelNames":     ["_TZ3000_g92baclx", "_TZ3000_kqvb5akv", "_TZ3000_mkhkxx1p", "_TZ3000_qnejhcsu", "_TZ3000_tgddllx4", "_TZ3000_x3ewpzyr", "_TZ3000_xkap8wtb"],
+      "modelNames":     ["_TZ3000_g92baclx", "_TZ3000_kqvb5akv", "_TZ3000_mkhkxx1p", "_TZ3000_qnejhcsu", "_TZ3000_tgddllx4", "_TZ3000_x3ewpzyr"],
       "properties":     ["status", "energy", "voltage", "current", "power", "tuyaPowerOnStatus"],
       "actions":        ["status", "tuyaPowerOnStatus"],
       "bindings":       ["status", "energy", "power"],
       "reportings":     ["status", "energy", "voltage", "current", "power"],
       "exposes":        ["switch", "powerOnStatus", "energy", "voltage", "current", "power"],
       "options":        {"powerOnStatus": {"enum": ["off", "on", "previous"]}, "energyDivider": 100, "currentDivider": 1000, "tuyaMagic": true, "skipAttributeRead": true}
+    },
+    {
+      "description":    "TUYA TS000F 1-Channel Relay with Power Monitoring",
+      "modelNames":     ["_TZ3000_xkap8wtb"],
+      "properties":     ["status", "energy", "voltage", "current", "power", "tuyaChildLock", "tuyaIndicatorMode", "tuyaSwitchType", "tuyaPowerOnStatus"],
+      "actions":        ["status", "tuyaChildLock", "tuyaIndicatorMode", "tuyaSwitchType", "tuyaPowerOnStatus"],
+      "bindings":       ["status", "energy", "power"],
+      "reportings":     ["status", "energy", "voltage", "current", "power"],
+      "exposes":        ["switch", "childLock", "indicatorMode", "switchType", "powerOnStatus", "energy", "voltage", "current", "power"],
+      "options":        {"switchType": {"enum": ["toggle", "static", "momentary"]}, "powerOnStatus": {"enum": ["off", "on", "previous"]}, "energyDivider": 100, "currentDivider": 1000, "tuyaMagic": true}
     },
     {
       "description":    "TUYA TS011F 1-Channel Relay with Power Monitoring",


### PR DESCRIPTION
Сейчас устройство прописано в этом блоке конфигурации:

https://github.com/u236/homed-service-zigbee/blob/44f34c49039c93ef904b8fbb153ecfcff2d4237e/deploy/data/usr/share/homed-zigbee/tuya.json#L900-L909


По факту есть отличия:

1. "Model name" определяется как "TS000F";
2. устройство не требует указания опции "skipAttributeRead";
3. рапортует о поддержке атрибутов из кластера TUYA_COMMON_PRIVATE cluster;
4. есть у него свои "гуси", которые, похоже, не лечатся - команда "toggle" работает только из состояния "off". Но об этом лучше оформлю issue.

Посему предлагаю выделить для этого реле отдельный блок конфигурации. Всё, что добавлено, было проверено на устройстве.
