### PR TITLE
add Linptech ES1ZZ(TY) initial support

### DIFF
--- a/deploy/data/usr/share/homed-zigbee/tuya.json
+++ b/deploy/data/usr/share/homed-zigbee/tuya.json
@@ -589,6 +589,31 @@
                         }
     },
     {
+      "description":    "Linptech ES1ZZ(TY) Human Presence Sensor",
+      "modelNames":     ["_TZ3218_awarhusb", "_TZ3218_t9ynfz4x"],
+      "properties":     ["iasOccupancy", "illuminance", "customAttributes", "tuyaDataPoints"],
+      "actions":        ["customAttributes", "tuyaDataPoints"],
+      "exposes":        ["occupancy", "illuminance", "targetDistance", "motionDetectionDistance", "presenceKeepTime", "motionSensitivity", "sensitivity", "fadingTime"],
+      "options":        {
+                          "customAttributes":
+                          {
+                            "motionDetectionDistance":  {"type": "value", "clusterId": 57346, "attributeId": 57355, "dataType": 33, "divider": 100, "action": true},
+                            "presenceKeepTime":         {"type": "value", "clusterId": 57346, "attributeId": 57345, "dataType": 33},
+                            "motionSensitivity":        {"type": "value", "clusterId": 57346, "attributeId": 57348, "dataType": 32, "action": true},
+                            "sensitivity":              {"type": "value", "clusterId": 57346, "attributeId": 57349, "dataType": 32, "action": true},
+                            "targetDistance":           {"type": "value", "clusterId": 57346, "attributeId": 57354, "dataType": 33, "divider": 100}
+                          },
+                          "tuyaDataPoints": {
+                            "101":  [{"name": "fadingTime", "type": "value", "action": true}]
+                          },
+                          "motionDetectionDistance": {"min": 0, "max": 6, "step": 0.5},
+                          "motionSensitivity": {"min": 0, "max": 5},
+                          "sensitivity": {"min": 0, "max": 5},
+                          "fadingTime": {"min": 0, "max": 10000, "step": 10},
+                          "tuyaMagic": true
+                        }
+    },
+    {
       "description":    "TUYA TS0601 Temperature and Humidity Sensor (Type A)",
       "modelNames":     ["_TZE200_a8sdabtg", "_TZE200_dikkika5", "_TZE200_qoy0ekbd", "_TZE200_znbl8dj5"],
       "properties":     ["tuyaDataPoints"],


### PR DESCRIPTION
Данный PR скорее просьба помочь разобраться с проблемой, а возможно и совместными усилиями добавить поддержку нового устройства.

Только начинаю разбираться что к чему, поэтому в моих изменениях могут быть неточности.

Пробую добавить поддержку датчика присутствия Linptech Presence Sensor ES1 (ES1ZZ(TY))
Модель _TZ3218_awarhusb (встречается также _TZ3218_t9ynfz4x)
https://www.aliexpress.com/item/1005006101306384.html

```
{
  "active": true,
  "cloud": true,
  "description": "Linptech ES1ZZ(TY) Human Presence Sensor",
  "discovery": true,
  "endpoints": [
    {
      "deviceId": 1026,
      "endpointId": 1,
      "inClusters": [
        0,
        3,
        4,
        5,
        57346,
        16384,
        61184,
        1280
      ],
      "outClusters": [
        10,
        25
      ],
      "profileId": 260
    }
  ],
  "ieeeAddress": "b0:c7:de:ff:fe:7e:1b:2c",
  "interviewFinished": true,
  "lastSeen": 1715448417,
  "linkQuality": 84,
  "logicalType": 1,
  "manufacturerCode": 4098,
  "manufacturerName": "_TZ3218_awarhusb",
  "modelName": "TS0225",
  "networkAddress": 55185,
  "powerSource": 1,
  "supported": true,
  "version": 70,
  "name": "b0:c7:de:ff:fe:7e:1b:2c"
}
```

Устройство поддерживается z2m
https://www.zigbee2mqtt.io/devices/ES1ZZ(TY).html
https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/linptech.ts

Топик с обсуждением, так как поддержка появилась относительно недавно
https://github.com/Koenkk/zigbee2mqtt/issues/18637

ID кластеров, атрибутов, типов данных, а также минимальные и максимальные значения настроек брал оттуда.
Так как в z2m используется имена кластеров, то ID брал отсюда: https://github.com/Koenkk/zigbee-herdsman/blob/924c45c724c929002490b04beeb40d77ffff6ec4/src/zspec/zcl/definition/cluster.ts

Увы, некоторые функции работают некорректно.

Из того, что точно работает:
- occupancy
- illuminance
- targetDistance
- presenceKeepTime (добавил для себя в /usr/share/homed-common/expose.json)
`"presenceKeepTime":           {"type": "sensor", "unit": "min", "icon": "mdi:timer"}`

Из того, что не работает корректно:
- fadingTime. устройство получает настройку, что видно по изменению occupancy спустя заданное время, но нет обратного ответа с  состоянием, из-за чего всегда отображается unknown. Единственный атрибут из tuyaDataPoints
- motionSensitivity и sensitivity. Motion detection sensitivity и Static detection sensitivity соответственно. После сброса устройства и подключения имеют значение 5, что соответствует максимальному (от 0 до 5). Если попробовать изменить настройки, то команда отправляется, и приходит ответ с тем же значением. Однако почему-то сразу же приходит состояние 0, поэтому невозможно настроить статическую чувствительность и чувствительность движения
```
2024.05.11 19:26:14.886 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" sensitivity action request finished successfully
2024.05.11 19:26:14.957 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe005" report received with type "0x20" and data "03" and transaction id 27
2024.05.11 19:26:15.307 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe005" report received with type "0x20" and data "03" and transaction id 70
2024.05.11 19:26:15.375 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe005" report received with type "0x20" and data "00" and transaction id 71
2024.05.11 19:26:16.277 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" motionSensitivity action request finished successfully
2024.05.11 19:26:16.348 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe004" report received with type "0x20" and data "03" and transaction id 31
2024.05.11 19:26:16.698 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe004" report received with type "0x20" and data "03" and transaction id 72
2024.05.11 19:26:16.767 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe004" report received with type "0x20" and data "00" and transaction id 73
```
- motionDetectionDistance (добавил для себя в /usr/share/homed-common/expose.json)
`"motionDetectionDistance":    {"type": "number", "unit": "m", "icon": "mdi:arrow-left-right"},`
то же самое что и с чувствительностью, приходит максимальное изначальное состояние (600 см или 6м если конвертировать). после изменения настройки - сброс до нуля.
```
2024.05.11 19:26:17.847 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" motionDetectionDistance action request finished successfully

2024.05.11 19:26:17.925 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe00b" report received with type "0x21" and data "58:02" and transaction id 35
2024.05.11 19:26:18.508 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe00b" report received with type "0x21" and data "00:00" and transaction id 75
```

Основной кластер: 0xe002

Лог файл: [homed.log](https://github.com/u236/homed-service-zigbee/files/15283757/homed.log)
Предварительно почистил строчки, не связанные с данным устройством.

Координатор: Sonoff ZBDongle-P
```
[zigbee]
adapter=znp
port=/dev/ttyUSB0
baudrate=115200
panid=0x1011
channel=11
reset=soft
write=false
```

У меня только один координатор, поэтому проверять работу в z2m не стал, дабы не сбрасывать настройки и не перепривязывать устройства заново.

Было бы здорово, если поможете проверить конфигурацию, возможно я что-то упускаю. Если нужно больше логов или включить debug для port или adapter, прошу дать знать. Заранее огромное спасибо!

UPD: Проверил работу устройства в z2m. настройки устанавливаются как положено, и даже после подключения к homed они же и принимаются, но в самом homed их установить не получаются, сбрасываются в ноль

На всякий случай лог установки sensitivity с включенным debug для port и adapter
```
2024.05.19 10:22:06.333 (inf) zigbee:    --> "0x2401" "65:41:01:01:02:e0:04:20:0f:07:10:00:02:05:e0:20:03"
2024.05.19 10:22:06.334 (inf) zigbee:    Serial data sent: "fe:11:24:01:65:41:01:01:02:e0:04:20:0f:07:10:00:02:05:e0:20:03:0a"
2024.05.19 10:22:06.370 (inf) zigbee:    Serial data received: "fe:01:64:01:00:64:fe:03:44:80:00:01:04:c2"
2024.05.19 10:22:06.371 (inf) zigbee:    Packet received: "fe:01:64:01:00:64"
2024.05.19 10:22:06.371 (inf) zigbee:    Packet received: "fe:03:44:80:00:01:04:c2"
2024.05.19 10:22:06.371 (inf) zigbee:    <-- "0x6401" "00"
2024.05.19 10:22:06.372 (inf) zigbee:    <-- "0x4480" "00:01:04"
2024.05.19 10:22:06.372 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" sensitivity action request finished successfully
2024.05.19 10:22:06.373 (inf) zigbee:    --> "0x2401" "65:41:01:01:02:e0:05:20:0f:05:10:05:00:05:e0"
2024.05.19 10:22:06.373 (inf) zigbee:    Serial data sent: "fe:0f:24:01:65:41:01:01:02:e0:05:20:0f:05:10:05:00:05:e0:33"
2024.05.19 10:22:06.410 (inf) zigbee:    Serial data received: "fe:18:44:81:00:00:02:e0:65:41:01:01:00:a0:00:fb:d0:21:00:00:04:18:00:04:00:65:41:1d:90:fe:01:64:01:00:64:fe:03:44:80:00:01:05:c3"
2024.05.19 10:22:06.410 (inf) zigbee:    Packet received: "fe:18:44:81:00:00:02:e0:65:41:01:01:00:a0:00:fb:d0:21:00:00:04:18:00:04:00:65:41:1d:90"
2024.05.19 10:22:06.411 (inf) zigbee:    Packet received: "fe:01:64:01:00:64"
2024.05.19 10:22:06.411 (inf) zigbee:    Packet received: "fe:03:44:80:00:01:05:c3"
2024.05.19 10:22:06.411 (inf) zigbee:    <-- "0x4481" "00:00:02:e0:65:41:01:01:00:a0:00:fb:d0:21:00:00:04:18:00:04:00:65:41:1d"
2024.05.19 10:22:06.412 (inf) zigbee:    <-- "0x6401" "00"
2024.05.19 10:22:06.412 (inf) zigbee:    <-- "0x4480" "00:01:05"
2024.05.19 10:22:06.433 (inf) zigbee:    Serial data received: "fe:1c:44:81:00:00:02:e0:65:41:01:01:00:a0:00:2c:da:21:00:00:08:18:05:01:05:e0:00:20:03:65:41:1d:83"
2024.05.19 10:22:06.434 (inf) zigbee:    Packet received: "fe:1c:44:81:00:00:02:e0:65:41:01:01:00:a0:00:2c:da:21:00:00:08:18:05:01:05:e0:00:20:03:65:41:1d:83"
2024.05.19 10:22:06.434 (inf) zigbee:    <-- "0x4481" "00:00:02:e0:65:41:01:01:00:a0:00:2c:da:21:00:00:08:18:05:01:05:e0:00:20:03:65:41:1d"
2024.05.19 10:22:06.434 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe005" report received with type "0x20" and data "03" and transaction id 5
2024.05.19 10:22:06.790 (inf) zigbee:    Serial data received: "fe:1b:44:81:00:00:02:e0:65:41:01:01:00:9c:00:28:33:22:00:00:07:08:23:0a:05:e0:20:03:65:41:1d:64"
2024.05.19 10:22:06.790 (inf) zigbee:    Packet received: "fe:1b:44:81:00:00:02:e0:65:41:01:01:00:9c:00:28:33:22:00:00:07:08:23:0a:05:e0:20:03:65:41:1d:64"
2024.05.19 10:22:06.791 (inf) zigbee:    <-- "0x4481" "00:00:02:e0:65:41:01:01:00:9c:00:28:33:22:00:00:07:08:23:0a:05:e0:20:03:65:41:1d"
2024.05.19 10:22:06.791 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe005" report received with type "0x20" and data "03" and transaction id 35
2024.05.19 10:22:06.792 (inf) zigbee:    --> "0x2401" "65:41:01:01:02:e0:06:20:0f:05:18:23:0b:0a:00"
2024.05.19 10:22:06.792 (inf) zigbee:    Serial data sent: "fe:0f:24:01:65:41:01:01:02:e0:06:20:0f:05:18:23:0b:0a:00:fa"
2024.05.19 10:22:06.829 (inf) zigbee:    Serial data received: "fe:01:64:01:00:64:fe:03:44:80:00:01:06:c0"
2024.05.19 10:22:06.829 (inf) zigbee:    Packet received: "fe:01:64:01:00:64"
2024.05.19 10:22:06.829 (inf) zigbee:    Packet received: "fe:03:44:80:00:01:06:c0"
2024.05.19 10:22:06.830 (inf) zigbee:    <-- "0x6401" "00"
2024.05.19 10:22:06.830 (inf) zigbee:    <-- "0x4480" "00:01:06"
2024.05.19 10:22:06.858 (inf) zigbee:    Serial data received: "fe:1b:44:81:00:00:02:e0:65:41:01:01:00:a0:00:a9:43:22:00:00:07:08:24:0a:05:e0:20:00:65:41:1d:ad"
2024.05.19 10:22:06.858 (inf) zigbee:    Packet received: "fe:1b:44:81:00:00:02:e0:65:41:01:01:00:a0:00:a9:43:22:00:00:07:08:24:0a:05:e0:20:00:65:41:1d:ad"
2024.05.19 10:22:06.859 (inf) zigbee:    <-- "0x4481" "00:00:02:e0:65:41:01:01:00:a0:00:a9:43:22:00:00:07:08:24:0a:05:e0:20:00:65:41:1d"
2024.05.19 10:22:06.859 (inf) zigbee:    Device "b0:c7:de:ff:fe:7e:1b:2c" endpoint "0x01" cluster "0xe002" attribute "0xe005" report received with type "0x20" and data "00" and transaction id 36
2024.05.19 10:22:06.860 (inf) zigbee:    --> "0x2401" "65:41:01:01:02:e0:07:20:0f:05:18:24:0b:0a:00"
2024.05.19 10:22:06.861 (inf) zigbee:    Serial data sent: "fe:0f:24:01:65:41:01:01:02:e0:07:20:0f:05:18:24:0b:0a:00:fc"
2024.05.19 10:22:06.897 (inf) zigbee:    Serial data received: "fe:01:64:01:00:64:fe:03:44:80:00:01:07:c1"
2024.05.19 10:22:06.897 (inf) zigbee:    Packet received: "fe:01:64:01:00:64"
2024.05.19 10:22:06.897 (inf) zigbee:    Packet received: "fe:03:44:80:00:01:07:c1"
2024.05.19 10:22:06.898 (inf) zigbee:    <-- "0x6401" "00"
2024.05.19 10:22:06.899 (inf) zigbee:    <-- "0x4480" "00:01:07"
```