### PR TITLE
feat: add SNZB-01P support

### DIFF
--- a/deploy/data/usr/share/homed-zigbee/sonoff.json
+++ b/deploy/data/usr/share/homed-zigbee/sonoff.json
@@ -50,6 +50,19 @@
       "reportings":     ["batteryPercentage"],
       "exposes":        ["battery", "action"],
       "options":        {"customCommands": {"action": {"clusterId": 6}}, "action": {"enum": ["hold", "doubleClick", "singleClick"]}}
+    },
+    {
+      "description":    "Sonoff Wireless Button SNZB-01P",
+      "modelNames":     ["SNZB-01P"],
+      "properties":     ["batteryPercentage", "customCommands"],
+      "bindings":       ["battery", "status"],
+      "reportings":     ["batteryPercentage"],
+      "exposes":        ["battery", "action"],
+      "options":        {
+                          "customCommands": {"action": {"clusterId": 6}},
+                          "action": {"enum": ["hold", "doubleClick", "singleClick"]},
+                          "powerSource": 3
+                        }
     }
   ],
 

--- a/deploy/data/usr/share/homed-zigbee/sonoff.json
+++ b/deploy/data/usr/share/homed-zigbee/sonoff.json
@@ -27,12 +27,12 @@
       "exposes":        ["battery", "temperature", "humidity"]
     },
     {
-      "description":    "Sonoff Door and Window Sensor SNZB-04",
-      "modelNames":     ["DS01"],
+      "description":    "Sonoff Door and Window Sensor SNZB-04 or SNZB-04P",
+      "modelNames":     ["DS01", "SNZB-04P"],
       "properties":     ["batteryPercentage", "iasContact"],
       "bindings":       ["battery"],
       "reportings":     ["batteryPercentage"],
-      "exposes":        ["battery", "contact", "batteryLow"]
+      "exposes":        ["battery", "contact", "batteryLow", "tamper"]
     },
     {
       "description":    "Sonoff Motion Sensor SNZB-03",
@@ -43,26 +43,13 @@
       "exposes":        ["battery", "occupancy", "batteryLow"]
     },
     {
-      "description":    "Sonoff Wireless Button SNZB-01",
-      "modelNames":     ["WB01", "WB-01"],
+      "description":    "Sonoff Wireless Button SNZB-01 or SNZB-01P",
+      "modelNames":     ["SNZB-01P", "WB01", "WB-01"],
       "properties":     ["batteryPercentage", "customCommands"],
       "bindings":       ["battery", "status"],
       "reportings":     ["batteryPercentage"],
       "exposes":        ["battery", "action"],
-      "options":        {"customCommands": {"action": {"clusterId": 6}}, "action": {"enum": ["hold", "doubleClick", "singleClick"]}}
-    },
-    {
-      "description":    "Sonoff Wireless Button SNZB-01P",
-      "modelNames":     ["SNZB-01P"],
-      "properties":     ["batteryPercentage", "customCommands"],
-      "bindings":       ["battery", "status"],
-      "reportings":     ["batteryPercentage"],
-      "exposes":        ["battery", "action"],
-      "options":        {
-                          "customCommands": {"action": {"clusterId": 6}},
-                          "action": {"enum": ["hold", "doubleClick", "singleClick"]},
-                          "powerSource": 3
-                        }
+      "options":        {"customCommands": {"action": {"clusterId": 6}}, "action": {"enum": ["hold", "doubleClick", "singleClick"]}, "powerSource": 3}
     }
   ],
 


### PR DESCRIPTION
https://github.com/u236/homed-service-zigbee/issues/168

Добавление поддержки SNZB-01P

Конвертер z2m: https://github.com/Koenkk/zigbee-herdsman-converters/blob/master/src/devices/sonoff.ts#L719

Примечание:
- В z2m конвертере есть явная привязка к типу питания "от батареи" в сравнении с SNZB-01.
`forcePowerSource({powerSource: 'Battery'})`
- Судя по описанию устройства из issue, тип питания определился как 0, то есть `POWER_SOURCE_UNKNOWN`. Не уверен, есть ли смысл явно указывать `POWER_SOURCE_BATTERY`, так как по коду `device->batteryPowered()` все равно будет возвращать true
- В z2m в expose и reporting для обоих моделей (SNZB-01 и SNZB-01P) также есть battery voltage. Как я понял, в коде homed может использоваться либо batteryPercentage, либо batteryVoltage для конечной проперти battery. Поэтому по аналогии с SNZB-01 оставил только batteryPercentage
- конвертер команд для моделей SNZB-01 и SNZB-01P одинаковые, поэтому просто скопировал.

