### PR TITLE
Add Tuya temperature and humidity sensor _TZ3000_saiqcn0y support

### DIFF
--- a/deploy/data/usr/share/homed-zigbee/tuya.json
+++ b/deploy/data/usr/share/homed-zigbee/tuya.json
@@ -1440,7 +1440,7 @@
     },
     {
       "description":    "TUYA TS0201 Temperature and Humidity Sensor",
-      "modelNames":     ["_TZ2000_a476raq2", "_TZ2000_zsfvulde", "_TZ3000_0s1izerx", "_TZ3000_6uzkisv2", "_TZ3000_8ybe88nf", "_TZ3000_bguser20", "_TZ3000_dowj6gyi", "_TZ3000_fllyghyj", "_TZ3000_xr3htd96", "_TZ3000_yd2e749y", "_TZ3210_alxkwn0h", "_TZE200_ysm4dsb1", "_TZ3000_zl1kmjqx"],
+      "modelNames":     ["_TZ2000_a476raq2", "_TZ2000_zsfvulde", "_TZ3000_0s1izerx", "_TZ3000_6uzkisv2", "_TZ3000_8ybe88nf", "_TZ3000_bguser20", "_TZ3000_dowj6gyi", "_TZ3000_fllyghyj", "_TZ3000_xr3htd96", "_TZ3000_yd2e749y", "_TZ3210_alxkwn0h", "_TZE200_ysm4dsb1", "_TZ3000_zl1kmjqx", "_TZ3000_saiqcn0y"],
       "properties":     ["batteryPercentage", "temperature", "humidity"],
       "exposes":        ["battery", "temperature", "humidity"]
     },


### PR DESCRIPTION
Добавил поддержку датчика температуры и влажности Tuya на модуле ZTU с питанием от 2х батарей AAA. Он и раньше работал, но на странице устройства был без зелёного чекбокса "Supported"