### PR TITLE
fix zboss start for esp

### DIFF
--- a/zboss.cpp
+++ b/zboss.cpp
@@ -43,7 +43,7 @@ static uint16_t const crc16Table[256] =
     0xf78f, 0xe606, 0xd49d, 0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330, 0x7bc7, 0x6a4e, 0x58d5, 0x495c, 0x3de3, 0x2c6a, 0x1ef1, 0x0f78
 };
 
-ZBoss::ZBoss(QSettings *config, QObject *parent) : Adapter(config, parent), m_clear(false)
+ZBoss::ZBoss(QSettings *config, QObject *parent) : Adapter(config, parent), m_clear(false), m_esp(false)
 {
     m_policy.append({ZBOSS_POLICY_TC_LINK_KEYS_REQUIRED,           0x00});
     m_policy.append({ZBOSS_POLICY_IC_REQUIRED,                     0x00});
@@ -566,6 +566,7 @@ void ZBoss::parseData(QByteArray &buffer)
     if (buffer.startsWith("ESP-ROM"))
     {
         handleReset();
+        m_esp = true;
         return;
     }
 
@@ -631,7 +632,7 @@ bool ZBoss::permitJoin(bool enabled)
 
     request.dstAddress = qToLittleEndian <quint16> (networkAddress);
 
-    if (!sendRequest(ZBOSS_ZDO_PERMIT_JOINING_REQ, QByteArray(reinterpret_cast <char*> (&request), sizeof(request))) || m_replyStatus)
+    if (!m_esp && (!sendRequest(ZBOSS_ZDO_PERMIT_JOINING_REQ, QByteArray(reinterpret_cast <char*> (&request), sizeof(request))) || m_replyStatus))
     {
         logWarning << "Permit join request failed";
         return false;

--- a/zboss.h
+++ b/zboss.h
@@ -230,7 +230,7 @@ public:
 
 private:
 
-    bool m_clear;
+    bool m_clear, m_esp;
 
     quint16 m_command;
     QByteArray m_replyData;

--- a/zboss.h
+++ b/zboss.h
@@ -4,6 +4,8 @@
 #define ZBOSS_REQUEST_TIMEOUT                           2000
 #define ZBOSS_RESET_DELAY                               2000
 
+#define ZBOSS_ESP_BOOT_LOG                              0x4553502D524F4D3A
+
 #define ZBOSS_SIGNATURE                                 0xDEAD
 #define ZBOSS_PROTOCOL_VERSION                          0x00
 #define ZBOSS_NCP_API_HL                                0x06
@@ -16,7 +18,7 @@
 
 #define ZBOSS_FLAG_ACK                                  0x01
 #define ZBOSS_FLAG_FIRST_FRAGMENT                       0x40
-#define ZBISS_FLAG_LAST_FRAGMENT                        0x80
+#define ZBOSS_FLAG_LAST_FRAGMENT                        0x80
 
 #define ZBOSS_GET_MODULE_VERSION                        0x0001
 #define ZBOSS_NCP_RESET                                 0x0002

--- a/zboss.h
+++ b/zboss.h
@@ -4,8 +4,6 @@
 #define ZBOSS_REQUEST_TIMEOUT                           2000
 #define ZBOSS_RESET_DELAY                               2000
 
-#define ZBOSS_ESP_BOOT_LOG                              0x4553502D524F4D3A
-
 #define ZBOSS_SIGNATURE                                 0xDEAD
 #define ZBOSS_PROTOCOL_VERSION                          0x00
 #define ZBOSS_NCP_API_HL                                0x06
@@ -249,6 +247,7 @@ private:
     void sendAcknowledge(void);
     void parsePacket(quint8 type, quint16 command, const QByteArray &data);
 
+    void handleReset(void);
     bool startCoordinator(void);
 
     void softReset(void) override;


### PR DESCRIPTION
Поправил работу zboss для esp32 с прошивкой https://github.com/andryblack/esp-coordinator

ZBOSS_GET_NWK_KEYS пришлось закомментить, вываливается ошибка, в Z2M подглядел, что этот пакет вообще не отправляется. Как иначе обойти ASCII, которое чип выплевывает после ресета, я не придумал))

ASCII который пишется после ресета:
> 45:53:50:2d:52:4f:4d:3a:65:73:70:33:32:63:36:2d:32:30:32:32:30:39:31:39:0d:0a:42:75:69:6c:64:3a:53:65:70:20:31:39:20:32:30:32:32:0d:0a:72:73:74:3a:30:78:63:20:28:53:57:5f:43:50:55:29:2c:62:6f:6f:74:3a:30:78:63:20:28:53:50:49:5f:46:41:53:54:5f:46:4c:41:53:48:5f:42:4f:4f:54:29:0d:0a:53:61:76:65:64:20:50:43:3a:30:78:34:30:30:31:39:37:35:61:0d:0a:53:50:49:57:50:3a:30:78:65:65:0d:0a:6d:6f:64:65:3a:44:49:4f:2c:20:63:6c:6f:63:6b:20:64:69:76:3a:32:0d:0a:6c:6f:61:64:3a:30:78:34:30:38:37:35:37:32:30:2c:6c:65:6e:3a:30:78:31:33:33:38:0d:0a:6c:6f:61:64:3a:30:78:34:30:38:36:63:31:31:30:2c:6c:65:6e:3a:30:78:63:37:30:0d:0a:6c:6f:61:64:3a:30:78:34:30:38:36:65:36:31:30:2c:6c:65:6e:3a:30:78:32:63:31:38:0d:0a:65:6e:74:72:79:20:30:78:34:30:38:36:63:31:31:30:0d:0a

> 
> ESP-ROM:esp32c6-20220919
> Build:Sep 19 2022
> rst:0xc (SW_CPU),boot:0xc (SPI_FAST_FLASH_BOOT)
> Saved PC:0x4001975a
> SPIWP:0xee
> mode:DIO, clock div:2
> load:0x40875720,len:0x1338
> load:0x4086c110,len:0xc70
> load:0x4086e610,len:0x2c18
> entry 0x4086c110
> 


![zboss1](https://github.com/user-attachments/assets/3bb745b7-d099-4dbc-941f-15e0c5a07ac5)
![zboss2](https://github.com/user-attachments/assets/5191502a-b057-4ef6-b6fa-0277d525e31d)
