### PR TITLE
Fix HOBEIAN wall switch exposing as an outlet

### DIFF
--- a/deploy/data/usr/share/homed-zigbee/other.json
+++ b/deploy/data/usr/share/homed-zigbee/other.json
@@ -79,7 +79,6 @@
       "bindings":       ["status"],
       "reportings":     ["status"],
       "exposes":        ["switch"],
-      "options":        {"switch": "outlet"},
       "endpointId":     [1, 2, 3]
     },
     {


### PR DESCRIPTION
Mistakenly added "switch": "outlet" - this is actually a wall switch, so remove this to represent properly in other smart home apps.